### PR TITLE
stop creating /nix for 2.2.x installers

### DIFF
--- a/lib/travis/build/script/nix.rb
+++ b/lib/travis/build/script/nix.rb
@@ -32,8 +32,6 @@ module Travis
           if config[:os] == 'linux'
             sh.cmd "sudo mount -o remount,exec /run"
             sh.cmd "sudo mount -o remount,exec /run/user"
-            sh.cmd "sudo mkdir -p -m 0755 /nix/"
-            sh.cmd "sudo chown $USER /nix/"
             sh.cmd "echo 'build-max-jobs = 4' | sudo tee /tmp/nix.conf > /dev/null"
           end
         end


### PR DESCRIPTION
Prior to https://github.com/NixOS/nix/pull/3054, the daemon installer required /nix to be empty. This no longer creates them. 

I *think* they are vestigial now that this uses a daemon install. But, I can't swear I *know* they're obsolete. :)

I believe this to be necessary because the installer is failing on Linux builds prior to 2.3.x with something like: https://staging.travis-ci.org/github/abathur/resholved/jobs/760484#L236